### PR TITLE
Add ONNX export and INT8 quantization workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # CASTING_RECOGNITION_AI
+
+## Quantization
+
+1. Install the required dependencies:
+   ```bash
+   pip install ultralytics onnxruntime onnxruntime-tools opencv-python
+   ```
+2. Export the trained weights to ONNX and produce an INT8 model:
+   ```bash
+   python quantize.py \
+       --weights runs/detect/train_fixed_aug/weights/best.pt \
+       --calib-images datasets/test/images
+   ```
+   * `best.onnx` will be created next to the weights file.
+   * An INT8 calibrated model named `best-int8.onnx` will be saved in the same directory.
+   * Use `--onnx-output` or `--int8-output` to save the outputs elsewhere.
+
+## Running inference with ONNX/INT8 models
+
+### Batch inference on a directory
+```bash
+python detect.py --model-path runs/detect/train_fixed_aug/weights/best-int8.onnx
+```
+Use `--image-dir`, `--project-dir`, or `--run-name` to adjust inputs and outputs. Pass `--no-show` to disable GUI windows.
+
+### Webcam stream
+```bash
+python camera_stream.py --model-path runs/detect/train_fixed_aug/weights/best-int8.onnx
+```
+Press `q` to stop the stream. Omit `--model-path` to fall back to the original `best.pt` weights.

--- a/detect.py
+++ b/detect.py
@@ -1,36 +1,107 @@
+"""Run batch inference on the test dataset using a trained YOLO model."""
+
+from __future__ import annotations
+
+import argparse
 import shutil
-import os
+from pathlib import Path
+from typing import List
+
 from ultralytics import YOLO
 
-def run_inference():
-    project_dir = r"C:\Workspace\CASTING_REGNITION_AI\runs\detect"
-    name = "predict_fixed_aug"  # 증강 학습 모델 결과 기반 추론
-    save_path = os.path.join(project_dir, name)
+DEFAULT_MODEL = Path("runs/detect/train_fixed_aug/weights/best.pt")
+DEFAULT_PROJECT_DIR = Path("runs/detect")
+DEFAULT_RUN_NAME = "predict_fixed_aug"
+DEFAULT_IMAGE_DIR = Path("datasets/test/images")
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp"}
 
-    # 실행 전 기존 결과 삭제
-    if os.path.exists(save_path):
+
+def list_images(image_dir: Path) -> List[Path]:
+    if not image_dir.exists():
+        raise FileNotFoundError(f"Image directory not found: {image_dir}")
+
+    images = [
+        path
+        for path in sorted(image_dir.iterdir())
+        if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS
+    ]
+    if not images:
+        raise RuntimeError(f"No images were found in: {image_dir}")
+    return images
+
+
+def load_model(model_path: Path) -> YOLO:
+    if model_path.suffix.lower() == ".onnx":
+        return YOLO(str(model_path))
+    return YOLO(str(model_path))
+
+
+def run_inference(
+    model_path: Path = DEFAULT_MODEL,
+    image_dir: Path = DEFAULT_IMAGE_DIR,
+    project_dir: Path = DEFAULT_PROJECT_DIR,
+    run_name: str = DEFAULT_RUN_NAME,
+    show: bool = True,
+) -> None:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    save_path = project_dir / run_name
+
+    if save_path.exists():
         shutil.rmtree(save_path)
 
-    model = YOLO(r"C:\Workspace\CASTING_REGNITION_AI\runs\detect\train_fixed_aug\weights\best.pt")
+    model = load_model(model_path)
+    image_paths = list_images(image_dir)
+    results = model([str(image) for image in image_paths], project=str(project_dir), name=run_name, save=True)
 
-    test_dir = r"C:\Workspace\CASTING_REGNITION_AI\datasets\test\images"
-    image_extensions = (".jpg", ".jpeg", ".png", ".bmp")
-    test_images = [
-        os.path.join(test_dir, f)
-        for f in os.listdir(test_dir)
-        if f.lower().endswith(image_extensions)
-    ]
+    if show:
+        for result in results:
+            result.show()
 
-    if not test_images:
-        print("테스트 이미지가 없습니다!")
-        return
 
-    # 추론 + 저장
-    results = model(test_images, project=project_dir, name=name, save=True)
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run YOLO inference on a directory of images.")
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=DEFAULT_MODEL,
+        help="Path to a YOLO model (.pt or .onnx).",
+    )
+    parser.add_argument(
+        "--image-dir",
+        type=Path,
+        default=DEFAULT_IMAGE_DIR,
+        help="Directory that contains images to run inference on.",
+    )
+    parser.add_argument(
+        "--project-dir",
+        type=Path,
+        default=DEFAULT_PROJECT_DIR,
+        help="Directory where prediction results will be stored.",
+    )
+    parser.add_argument(
+        "--run-name",
+        type=str,
+        default=DEFAULT_RUN_NAME,
+        help="Name of the prediction run directory.",
+    )
+    parser.add_argument(
+        "--no-show",
+        action="store_true",
+        help="Disable interactive result windows.",
+    )
+    return parser.parse_args()
 
-    # 화면 출력
-    for result in results:
-        result.show()
+
+def main() -> None:
+    args = parse_args()
+    run_inference(
+        model_path=args.model_path,
+        image_dir=args.image_dir,
+        project_dir=args.project_dir,
+        run_name=args.run_name,
+        show=not args.no_show,
+    )
+
 
 if __name__ == "__main__":
-    run_inference()
+    main()


### PR DESCRIPTION
## Summary
- add a quantization utility that exports best.pt to ONNX and calibrates an INT8 model using datasets/test/images
- update detect.py and camera_stream.py to accept configurable model paths including ONNX models
- document the quantization workflow and ONNX/INT8 inference usage in the README

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d5e643a44483239a0bdf420a5f82a6