### PR TITLE
Allow configuring local paths for training and inference

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -3,17 +3,38 @@
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from ultralytics import YOLO
 
-DEFAULT_MODEL = Path("runs/detect/train_fixed_aug/weights/best.pt")
-DEFAULT_PROJECT_DIR = Path("runs/detect")
+ENV_BASE_DIR = "CASTING_AI_BASE_DIR"
+DEFAULT_MODEL_PATH = Path("runs/detect/train_fixed_aug/weights/best.pt")
+DEFAULT_PROJECT_SUBDIR = Path("runs/detect")
 DEFAULT_RUN_NAME = "predict_fixed_aug"
 DEFAULT_IMAGE_DIR = Path("datasets/test/images")
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp"}
+
+
+def resolve_base_dir(base_dir: Optional[Path]) -> Path:
+    if base_dir is not None:
+        return Path(base_dir).expanduser()
+
+    env_base_dir = os.getenv(ENV_BASE_DIR)
+    if env_base_dir:
+        return Path(env_base_dir).expanduser()
+
+    return Path(__file__).resolve().parent
+
+
+def resolve_path(path: Path | str, base_dir: Path) -> Path:
+    candidate = Path(path).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    return base_dir / candidate
+
 
 # 지정한 폴더에서 추론에 사용할 이미지 목록을 만드는 함수
 def list_images(image_dir: Path) -> List[Path]:
@@ -29,42 +50,72 @@ def list_images(image_dir: Path) -> List[Path]:
         raise RuntimeError(f"No images were found in: {image_dir}")
     return images
 
+
 # 경로에 맞춰 YOLO 모델을 로드하는 함수
 def load_model(model_path: Path) -> YOLO:
-    if model_path.suffix.lower() == ".onnx":
-        return YOLO(str(model_path))
     return YOLO(str(model_path))
+
 
 # YOLO 모델로 배치 추론을 수행하고 결과를 저장하는 함수
 def run_inference(
-    model_path: Path = DEFAULT_MODEL,
+    *,
+    base_dir: Optional[Path] = None,
+    model_path: Path = DEFAULT_MODEL_PATH,
     image_dir: Path = DEFAULT_IMAGE_DIR,
-    project_dir: Path = DEFAULT_PROJECT_DIR,
+    project_dir: Path = DEFAULT_PROJECT_SUBDIR,
     run_name: str = DEFAULT_RUN_NAME,
     show: bool = True,
+    overwrite: bool = True,
 ) -> None:
-    project_dir.mkdir(parents=True, exist_ok=True)
+    resolved_base_dir = resolve_base_dir(base_dir)
+    project_dir = resolve_path(project_dir, resolved_base_dir)
+    image_dir = resolve_path(image_dir, resolved_base_dir)
+    model_path = resolve_path(model_path, resolved_base_dir)
     save_path = project_dir / run_name
 
-    if save_path.exists():
+    project_dir.mkdir(parents=True, exist_ok=True)
+    if overwrite and save_path.exists():
         shutil.rmtree(save_path)
+    elif not overwrite and save_path.exists():
+        raise FileExistsError(
+            f"Prediction output directory already exists: {save_path}. "
+            "Use --run-name or enable overwriting to continue."
+        )
+
+    if not model_path.exists():
+        raise FileNotFoundError(f"Model file not found: {model_path}")
 
     model = load_model(model_path)
     image_paths = list_images(image_dir)
-    results = model([str(image) for image in image_paths], project=str(project_dir), name=run_name, save=True)
+    results = model(
+        [str(image) for image in image_paths],
+        project=str(project_dir),
+        name=run_name,
+        save=True,
+    )
 
     if show:
         for result in results:
             result.show()
 
+
 # 커맨드라인 인자를 파싱하는 함수
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run YOLO inference on a directory of images.")
     parser.add_argument(
+        "--base-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Base directory used to resolve relative paths. "
+            "Defaults to $CASTING_AI_BASE_DIR or the script directory."
+        ),
+    )
+    parser.add_argument(
         "--model-path",
         type=Path,
-        default=DEFAULT_MODEL,
-        help="Path to a YOLO model (.pt or .onnx).",
+        default=DEFAULT_MODEL_PATH,
+        help="Relative path to a YOLO model (.pt or .onnx).",
     )
     parser.add_argument(
         "--image-dir",
@@ -75,7 +126,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--project-dir",
         type=Path,
-        default=DEFAULT_PROJECT_DIR,
+        default=DEFAULT_PROJECT_SUBDIR,
         help="Directory where prediction results will be stored.",
     )
     parser.add_argument(
@@ -89,17 +140,25 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Disable interactive result windows.",
     )
+    parser.add_argument(
+        "--keep-existing",
+        action="store_true",
+        help="Do not delete an existing prediction directory.",
+    )
     return parser.parse_args()
+
 
 # 스크립트 실행 흐름을 담당하는 메인 함수
 def main() -> None:
     args = parse_args()
     run_inference(
+        base_dir=args.base_dir,
         model_path=args.model_path,
         image_dir=args.image_dir,
         project_dir=args.project_dir,
         run_name=args.run_name,
         show=not args.no_show,
+        overwrite=not args.keep_existing,
     )
 
 

--- a/train.py
+++ b/train.py
@@ -1,43 +1,183 @@
-from pathlib import Path
+"""Utilities for training the YOLO model used in the project."""
+
+from __future__ import annotations
+
+import argparse
+import os
 import shutil
+from pathlib import Path
+from typing import Optional
+
 from ultralytics import YOLO
+
+ENV_BASE_DIR = "CASTING_AI_BASE_DIR"
+DEFAULT_RUN_NAME = "train_fixed_aug"
+DEFAULT_PROJECT_SUBDIR = Path("runs/detect")
+DEFAULT_DATA_CONFIG = Path("datasets/data.yaml")
+DEFAULT_MODEL_WEIGHTS = "yolov8s-seg.pt"
+
+
+def resolve_base_dir(base_dir: Optional[Path]) -> Path:
+    """Return the directory that relative paths should be resolved against."""
+    if base_dir is not None:
+        return Path(base_dir).expanduser()
+
+    env_base_dir = os.getenv(ENV_BASE_DIR)
+    if env_base_dir:
+        return Path(env_base_dir).expanduser()
+
+    return Path(__file__).resolve().parent
+
+
+def resolve_path(path: Path | str, base_dir: Path) -> Path:
+    """Resolve *path* relative to *base_dir* if it is not already absolute."""
+    candidate = Path(path).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    return base_dir / candidate
+
+
+def remove_previous_run(save_path: Path, project_dir: Path) -> None:
+    """Remove a previous training run directory if it lives under *project_dir*."""
+    if not save_path.exists():
+        return
+
+    try:
+        save_path.resolve().relative_to(project_dir.resolve())
+    except ValueError as exc:  # pragma: no cover - guard clause
+        raise RuntimeError(
+            f"Refusing to delete path outside {project_dir}: {save_path}"
+        ) from exc
+
+    shutil.rmtree(save_path)
 
 
 # 학습 파이프라인을 구성하고 YOLO 모델을 훈련하는 함수
-def train_model():
-    root_dir = Path(__file__).resolve().parent.parent
-    project_dir = root_dir / "runs" / "detect"
-    name = "train_fixed_aug"
-    save_path = project_dir / name
+
+def train_model(
+    *,
+    base_dir: Optional[Path] = None,
+    data_config: Path = DEFAULT_DATA_CONFIG,
+    project_dir: Path = DEFAULT_PROJECT_SUBDIR,
+    run_name: str = DEFAULT_RUN_NAME,
+    model_weights: str | Path = DEFAULT_MODEL_WEIGHTS,
+    epochs: int = 25,
+    imgsz: int = 640,
+    batch: int = 12,
+    auto_augment: Optional[str] = None,
+    overwrite: bool = True,
+) -> None:
+    resolved_base_dir = resolve_base_dir(base_dir)
+    project_dir = resolve_path(project_dir, resolved_base_dir)
+    save_path = project_dir / run_name
 
     project_dir.mkdir(parents=True, exist_ok=True)
+    if overwrite:
+        remove_previous_run(save_path, project_dir)
+    elif save_path.exists():
+        raise FileExistsError(
+            f"Training output directory already exists: {save_path}. "
+            "Use --run-name or enable overwriting to continue."
+        )
 
-    if save_path.exists():
-        try:
-            save_path.resolve().relative_to(project_dir)
-        except ValueError as exc:
-            raise RuntimeError(f"Refusing to delete path outside {project_dir}: {save_path}") from exc
-
-        try:
-            shutil.rmtree(save_path)
-        except OSError as exc:
-            raise RuntimeError(f"Failed to remove previous run directory: {save_path}") from exc
-
-    data_path = root_dir / "datasets" / "data.yaml"
+    data_path = resolve_path(data_config, resolved_base_dir)
     if not data_path.exists():
         raise FileNotFoundError(f"Dataset config not found: {data_path}")
 
-    model = YOLO("yolov8s-seg.pt")
+    if isinstance(model_weights, Path):
+        weights_arg: str | Path = resolve_path(model_weights, resolved_base_dir)
+    else:
+        weight_str = str(model_weights)
+        candidate = Path(weight_str).expanduser()
+        has_path_separator = any(sep in weight_str for sep in {os.sep, os.altsep} if sep)
+        if has_path_separator or candidate.exists():
+            weights_arg = resolve_path(candidate, resolved_base_dir)
+        else:
+            weights_arg = weight_str
+
+    if isinstance(weights_arg, Path) and not weights_arg.exists():
+        raise FileNotFoundError(f"Model weights not found: {weights_arg}")
+
+    model = YOLO(str(weights_arg))
 
     model.train(
         data=str(data_path),
-        epochs=25,
-        imgsz=640,
-        batch=12,
+        epochs=epochs,
+        imgsz=imgsz,
+        batch=batch,
         project=str(project_dir),
-        name=name,
-        auto_augment=None,
+        name=run_name,
+        auto_augment=auto_augment,
     )
 
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train the YOLO segmentation model.")
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Base directory used to resolve relative paths. "
+            "Defaults to $CASTING_AI_BASE_DIR or the script directory."
+        ),
+    )
+    parser.add_argument(
+        "--data-config",
+        type=Path,
+        default=DEFAULT_DATA_CONFIG,
+        help="Relative path to the dataset YAML file (resolved against the base dir).",
+    )
+    parser.add_argument(
+        "--project-dir",
+        type=Path,
+        default=DEFAULT_PROJECT_SUBDIR,
+        help="Directory where training runs will be stored (relative to the base dir).",
+    )
+    parser.add_argument(
+        "--run-name",
+        type=str,
+        default=DEFAULT_RUN_NAME,
+        help="Name of the training run directory.",
+    )
+    parser.add_argument(
+        "--model-weights",
+        type=str,
+        default=DEFAULT_MODEL_WEIGHTS,
+        help="Initial YOLO weights to start training from.",
+    )
+    parser.add_argument("--epochs", type=int, default=25)
+    parser.add_argument("--imgsz", type=int, default=640)
+    parser.add_argument("--batch", type=int, default=12)
+    parser.add_argument(
+        "--auto-augment",
+        type=str,
+        default=None,
+        help="Optional auto augment policy passed to Ultralytics.",
+    )
+    parser.add_argument(
+        "--keep-existing",
+        action="store_true",
+        help="Do not delete an existing run directory with the same name.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    train_model(
+        base_dir=args.base_dir,
+        data_config=args.data_config,
+        project_dir=args.project_dir,
+        run_name=args.run_name,
+        model_weights=args.model_weights,
+        epochs=args.epochs,
+        imgsz=args.imgsz,
+        batch=args.batch,
+        auto_augment=args.auto_augment,
+        overwrite=not args.keep_existing,
+    )
+
+
 if __name__ == "__main__":
-    train_model()
+    main()


### PR DESCRIPTION
## Summary
- resolve dataset, weight, and output locations relative to a configurable base directory in both scripts
- add CLI options and environment variable support so notebooks and Raspberry Pi deployments share the same code paths
- improve safety checks by guarding run directory deletion and validating model files before execution

## Testing
- python -m compileall train.py detect.py

------
https://chatgpt.com/codex/tasks/task_e_68de3af43bd48323889d9e6fea75cf03