### PR TITLE
Handle base dir relative weight files

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,57 @@
+"""Tests for the train module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+stub_ultralytics = types.ModuleType("ultralytics")
+
+
+class _StubYOLO:  # pragma: no cover - simple stub used for import
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def train(self, *args, **kwargs):
+        return None
+
+
+stub_ultralytics.YOLO = _StubYOLO
+sys.modules.setdefault("ultralytics", stub_ultralytics)
+
+import train
+
+
+def test_train_model_resolves_weights_relative_to_base_dir(tmp_path):
+    """Ensure string weights names resolve relative to the provided base dir."""
+
+    base_dir = tmp_path
+    (base_dir / "datasets").mkdir()
+    data_config = base_dir / "datasets" / "data.yaml"
+    data_config.write_text("path: datasets\n")
+
+    weights_file = base_dir / "custom.pt"
+    weights_file.write_text("dummy weights")
+
+    with patch.object(train, "YOLO") as mock_yolo:
+        mock_yolo.return_value.train.return_value = None
+
+        train.train_model(
+            base_dir=base_dir,
+            data_config=Path("datasets/data.yaml"),
+            project_dir=Path("runs/detect"),
+            run_name="test-run",
+            model_weights="custom.pt",
+            epochs=1,
+            imgsz=8,
+            batch=1,
+        )
+
+    assert mock_yolo.call_args is not None
+    (weights_arg,), _ = mock_yolo.call_args
+    assert Path(weights_arg) == weights_file

--- a/train.py
+++ b/train.py
@@ -89,9 +89,15 @@ def train_model(
     else:
         weight_str = str(model_weights)
         candidate = Path(weight_str).expanduser()
+        resolved_candidate = resolve_path(candidate, resolved_base_dir)
         has_path_separator = any(sep in weight_str for sep in {os.sep, os.altsep} if sep)
-        if has_path_separator or candidate.exists():
-            weights_arg = resolve_path(candidate, resolved_base_dir)
+
+        if resolved_candidate.exists():
+            weights_arg = resolved_candidate
+        elif candidate.exists():
+            weights_arg = candidate
+        elif has_path_separator:
+            weights_arg = resolved_candidate
         else:
             weights_arg = weight_str
 


### PR DESCRIPTION
## Summary
- resolve string model weight arguments relative to the configured base directory when present
- add a unit test that verifies CLI-style weight filenames load from the base directory while stubbing ultralytics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de3fb58bb883239076f1c04d1adaab